### PR TITLE
Enhance get_list_of_xx calls by allowing for filter by network id

### DIFF
--- a/libcloud/loadbalancer/drivers/dimensiondata.py
+++ b/libcloud/loadbalancer/drivers/dimensiondata.py
@@ -173,18 +173,26 @@ class DimensionDataLBDriver(Driver):
                    'listener_ip_address': ex_listener_ip_address}
         )
 
-    def list_balancers(self):
+    def list_balancers(self, network_id=None):
         """
-        List all loadbalancers inside a geography.
+        List all loadbalancers inside a geography or in given network.
 
         In Dimension Data terminology these are known as virtual listeners
 
+        :param network_id: UUID of Network Domain
+               if not None returns only balancers in the given network
+               if None then returns all pools for the organization
+        :type  network_id: ``str``
+
         :rtype: ``list`` of :class:`LoadBalancer`
         """
+        params = None
+        if ( network_id is not None ):
+            params = { "networkDomainId": network_id }
 
         return self._to_balancers(
             self.connection
-            .request_with_orgId_api_2('networkDomainVip/virtualListener')
+            .request_with_orgId_api_2('networkDomainVip/virtualListener', params=params)
             .object)
 
     def get_balancer(self, balancer_id):
@@ -685,15 +693,25 @@ class DimensionDataLBDriver(Driver):
             status=State.RUNNING
         )
 
-    def ex_get_pools(self):
+    def ex_get_pools(self, network_id=None):
         """
-        Get all of the pools inside the current geography
+        Get all of the pools inside the current geography or
+        in given network.
+
+        :param network_id: UUID of Network Domain
+               if not None returns only balancers in the given network
+               if None then returns all pools for the organization
+        :type  network_id: ``str``
 
         :return: Returns a ``list`` of type ``DimensionDataPool``
         :rtype: ``list`` of ``DimensionDataPool``
         """
+        params = None
+        if ( network_id is not None ):
+            params = { "networkDomainId": network_id }
+
         pools = self.connection \
-            .request_with_orgId_api_2('networkDomainVip/pool').object
+            .request_with_orgId_api_2('networkDomainVip/pool', params=params).object
         return self._to_pools(pools)
 
     def ex_get_pool(self, pool_id):
@@ -833,15 +851,24 @@ class DimensionDataLBDriver(Driver):
             response_code = findtext(result, 'responseCode', TYPES_URN)
             return response_code in ['IN_PROGRESS', 'OK']
 
-    def ex_get_nodes(self):
+    def ex_get_nodes(self, network_id=None):
         """
-        Get the nodes within this geography
+        Get the nodes within this geography or in given network.
+
+        :param network_id: UUID of Network Domain
+               if not None returns only balancers in the given network
+               if None then returns all pools for the organization
+        :type  network_id: ``str``
 
         :return: Returns an ``list`` of ``DimensionDataVIPNode``
         :rtype: ``list`` of ``DimensionDataVIPNode``
         """
+        params = None
+        if ( network_id is not None ):
+            params = { "networkDomainId": network_id }
+
         nodes = self.connection \
-            .request_with_orgId_api_2('networkDomainVip/node').object
+            .request_with_orgId_api_2('networkDomainVip/node', params=params).object
         return self._to_nodes(nodes)
 
     def ex_get_node(self, node_id):


### PR DESCRIPTION
## Enhance get_list_of_xx calls by allowing for filter by network id
### Description

While developing utils using libcloud, I found that there were several routines in the LoadBalancer driver that just did not seem right.  Specifically, these were the "get a list of XXX"-type routines.  I felt (and others agreed) that it was "less than ideal" that these routines all defaulted to "return EVERYTHING from your company across ALL networks".  Initially, I _assumed_ that it would filter by network (since I had already told the LB Driver what my network Id was.  However, in testing my util, I found that it return LoadBalancers (in my case) from networks that I had never heard of.

Therefore, I created this PR.  The interface changes are BACKWARDS compatible.
For example:
    def list_balancers(self)     ==>     def list_balancers(self, network_id=None)
### Status

This code has been tested to show that:
- by default, the original all-encompassing lists are returned.
- using the new parameter, a list that only applies to the given network id is returned.

I do have several more tests that I want to run.  I won't be able to get to those until 8/31/16 though.
### Checklist (tick everything that applies)
- I will get to these (and update the PR as needed) on the 31st.
- I just wanted to get you this code as soon as possible.
- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

NOTE: We took this "concept" and applied to all the places that WE needed.  This _may_ apply to the compute and backup drivers as well.
